### PR TITLE
Export all models types

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,6 @@ module github.com/sudodeo/betterstack-go
 
 go 1.21.0
 
-replace github.com/sudodeo/betterstack-go => github.com/truvity/betterstack-go v0.0.0-20250114095632-22cc3bc0e05d
-
 require (
 	github.com/joho/godotenv v1.5.1
 	github.com/stretchr/testify v1.8.4

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/sudodeo/betterstack-go
 
 go 1.21.0
 
+replace github.com/sudodeo/betterstack-go => github.com/truvity/betterstack-go v0.0.0-20250114095632-22cc3bc0e05d
+
 require (
 	github.com/joho/godotenv v1.5.1
 	github.com/stretchr/testify v1.8.4

--- a/models/groups_response.go
+++ b/models/groups_response.go
@@ -3,17 +3,17 @@ package models
 // Groups represents the response body for monitor groups and heartbeat groups
 type Groups struct {
 	Data       []Group    `json:"data"`
-	Pagination pagination `json:"pagination"`
+	Pagination Pagination `json:"pagination"`
 }
 
 // Group represents the a monitor group or heartbeat group
 type Group struct {
 	ID         string          `json:"id,omitempty"`
 	Type       string          `json:"type,omitempty"`
-	Attributes groupAttributes `json:"attributes,omitempty"`
+	Attributes GroupAttributes `json:"attributes,omitempty"`
 }
 
-type groupAttributes struct {
+type GroupAttributes struct {
 	Name      string `json:"name,omitempty"`
 	SortIndex int    `json:"sort_index,omitempty"`
 	CreatedAt string `json:"created_at,omitempty"`

--- a/models/heartbeats_response.go
+++ b/models/heartbeats_response.go
@@ -3,17 +3,17 @@ package models
 // Heartbeats represents a response containing a list of Heartbeats
 type Heartbeats struct {
 	Data       []Heartbeat
-	Pagination pagination
+	Pagination Pagination
 }
 
 // Heartbeat represents a Heartbeat
 type Heartbeat struct {
 	ID         string
 	Type       string
-	Attributes heartbeatAttributes
+	Attributes HeartbeatAttributes
 }
 
-type heartbeatAttributes struct {
+type HeartbeatAttributes struct {
 	URL              string `json:"url"`
 	Name             string `json:"name"`               // The name of the service for this heartbeat.
 	Period           int    `json:"period"`             // How often should we expect this heartbeat? In seconds Minimum value: 30 seconds

--- a/models/incidents_response.go
+++ b/models/incidents_response.go
@@ -3,18 +3,18 @@ package models
 // Incidents represents a collection of incidents.
 type Incidents struct {
 	Data       []Incident `json:"data,omitempty"`
-	Pagination pagination `json:"pagination,omitempty"`
+	Pagination Pagination `json:"pagination,omitempty"`
 }
 
 // Incident represents an incident.
 type Incident struct {
 	ID            string             `json:"id,omitempty"`
 	Type          string             `json:"type,omitempty"`
-	Attributes    incidentAttributes `json:"attributes,omitempty"`
-	Relationships relationships      `json:"relationships,omitempty"`
+	Attributes    IncidentAttributes `json:"attributes,omitempty"`
+	Relationships Relationships      `json:"relationships,omitempty"`
 }
 
-type incidentAttributes struct {
+type IncidentAttributes struct {
 	Name               string   `json:"name,omitempty"`
 	URL                string   `json:"url,omitempty"`
 	HTTPMethod         string   `json:"http_method,omitempty"`
@@ -40,34 +40,34 @@ type incidentAttributes struct {
 
 // IncidentTimelineEvents represents a list of timeline events associated with an incident.
 type IncidentTimelineEvents struct {
-	Data []timelineItem `json:"data,omitempty"`
+	Data []TimelineItem `json:"data,omitempty"`
 }
 
-type timelineItem struct {
+type TimelineItem struct {
 	ID         string                 `json:"id,omitempty"`
 	Type       string                 `json:"type,omitempty"`
-	Attributes timelineItemAttributes `json:"attributes,omitempty"`
+	Attributes TimelineItemAttributes `json:"attributes,omitempty"`
 }
 
-type timelineItemAttributes struct {
+type TimelineItemAttributes struct {
 	ItemType string       `json:"item_type,omitempty"`
 	At       string       `json:"at,omitempty"`
-	Data     timelineData `json:"data,omitempty"`
+	Data     TimelineData `json:"data,omitempty"`
 }
 
-type timelineData struct {
+type TimelineData struct {
 	Title       string       `json:"title,omitempty"`
 	Content     string       `json:"content,omitempty"`
-	Attachments []attachment `json:"attachments,omitempty"`
+	Attachments []Attachment `json:"attachments,omitempty"`
 	Links       []string     `json:"links,omitempty"`
 }
 
-type content struct {
+type Content struct {
 	Text string `json:"text,omitempty"`
-	User user   `json:"user,omitempty"`
+	User User   `json:"user,omitempty"`
 }
 
-type attachment struct {
+type Attachment struct {
 	Size     int    `json:"size,omitempty"`
 	Filename string `json:"filename,omitempty"`
 	MimeType string `json:"mime_type,omitempty"`

--- a/models/metadata_request.go
+++ b/models/metadata_request.go
@@ -8,7 +8,7 @@ type MetadataRecordReqBody struct {
 	Value     string `json:"value,omitempty"` // Optional, Metadata value
 }
 
-type owner struct {
+type Owner struct {
 	Monitor            string
 	Heartbeat          string
 	Incident           string
@@ -17,7 +17,7 @@ type owner struct {
 }
 
 // OwnerType represents the type of owner for a metadata request.
-var OwnerType = owner{
+var OwnerType = Owner{
 	Monitor:            "Monitor",
 	Heartbeat:          "Heartbeat",
 	Incident:           "Incident",

--- a/models/metadata_response.go
+++ b/models/metadata_response.go
@@ -3,18 +3,18 @@ package models
 // Metadata represents the metadata information in the response.
 type Metadata struct {
 	Data       []MetadataRecord `json:"data,omitempty"`       // Data contains the metadata records.
-	Pagination pagination       `json:"pagination,omitempty"` // Pagination contains the pagination information.
+	Pagination Pagination       `json:"pagination,omitempty"` // Pagination contains the pagination information.
 }
 
 // MetadataRecord represents a metadata record in the response.
 type MetadataRecord struct {
 	ID            string             `json:"id,omitempty"`
 	Type          string             `json:"type,omitempty"`
-	Attributes    metadataAttributes `json:"attributes,omitempty"`
-	Relationships relationships      `json:"relationships,omitempty"`
+	Attributes    MetadataAttributes `json:"attributes,omitempty"`
+	Relationships Relationships      `json:"relationships,omitempty"`
 }
 
-type metadataAttributes struct {
+type MetadataAttributes struct {
 	Key   string `json:"key,omitempty"`
 	Value string `json:"value,omitempty"`
 }

--- a/models/monitors_request.go
+++ b/models/monitors_request.go
@@ -111,7 +111,7 @@ type MonitorUpdateReqBody struct {
 	ScenarioName        string          `json:"scenario_name,omitempty"`         // Name of the scenario identifying the playwright script
 }
 
-type monitorTypes struct {
+type MonitorTypes struct {
 	Status             string // check your website for a 2XX HTTP status code
 	ExpectedStatusCode string // check if your website returned one of the values in expected_status_codes.
 	Keyword            string // check if your website contains the required_keyword.
@@ -125,7 +125,7 @@ type monitorTypes struct {
 }
 
 // MonitorTypeList is a list of valid betterstack monitor types
-var MonitorTypeList = monitorTypes{
+var MonitorTypeList = MonitorTypes{
 	Status:             "status",
 	ExpectedStatusCode: "expected_status_code",
 	Keyword:            "keyword",

--- a/models/monitors_request.go
+++ b/models/monitors_request.go
@@ -44,7 +44,7 @@ type MonitorCreateReqBody struct {
 	Call                bool            `json:"call,omitempty"`                  // Phone call alerts
 	Push                bool            `json:"push,omitempty"`                  // Should we send a push notification to the on-call person?
 	CheckFrequency      int             `json:"check_frequency,omitempty"`       // Check frequency (in seconds)
-	RequestHeaders      []requestHeader `json:"request_headers,omitempty"`       // The request headers that will be send with the check
+	RequestHeaders      []RequestHeader `json:"request_headers,omitempty"`       // The request headers that will be send with the check
 	ExpectedStatusCodes []int           `json:"expected_status_codes,omitempty"` // An array of status codes you expect to receive from your website. These status codes are considered only if the monitor_type is expected_status_code.
 	DomainExpiration    int             `json:"domain_expiration,omitempty"`     // How many days before the domain expires do you want to be alerted? Valid values are 1, 2, 3, 7, 14, 30, and 60.
 	SSLExpiration       int             `json:"ssl_expiration,omitempty"`        // How many days before the SSL certificate expires do you want to be alerted? Valid values are 1, 2, 3, 7, 14, 30, and 60.
@@ -82,7 +82,7 @@ type MonitorUpdateReqBody struct {
 	Call                bool            `json:"call,omitempty"`                  // Phone call alerts
 	Push                bool            `json:"push,omitempty"`                  // Should we send a push notification to the on-call person?
 	CheckFrequency      int             `json:"check_frequency,omitempty"`       // Check frequency (in seconds)
-	RequestHeaders      []requestHeader `json:"request_headers,omitempty"`       // The request headers that will be send with the check
+	RequestHeaders      []RequestHeader `json:"request_headers,omitempty"`       // The request headers that will be send with the check
 	ExpectedStatusCodes []int           `json:"expected_status_codes,omitempty"` // An array of status codes you expect to receive from your website. These status codes are considered only if the monitor_type is expected_status_code.
 	DomainExpiration    int             `json:"domain_expiration,omitempty"`     // How many days before the domain expires do you want to be alerted? Valid values are 1, 2, 3, 7, 14, 30, and 60.
 	SSLExpiration       int             `json:"ssl_expiration,omitempty"`        // How many days before the SSL certificate expires do you want to be alerted? Valid values are 1, 2, 3, 7, 14, 30, and 60.

--- a/models/monitors_response.go
+++ b/models/monitors_response.go
@@ -3,7 +3,7 @@ package models
 // Monitors represents a response containing a list of responses
 type Monitors struct {
 	Data       []Monitor  `json:"data"`
-	Pagination pagination `json:"pagination"`
+	Pagination Pagination `json:"pagination"`
 }
 
 // Monitor represents a monitor
@@ -42,7 +42,7 @@ type MonitorAttributes struct {
 	MaintenanceTo       string          `json:"maintenance_to"`
 	MaintenanceTimezone string          `json:"maintenance_timezone"`
 	MaintenanceDays     []string        `json:"maintenance_days"`
-	Relationships       relationships   `json:"relationships"`
+	Relationships       Relationships   `json:"relationships"`
 	PausedAt            string          `json:"paused_at"`
 	CreatedAt           string          `json:"created_at"`
 	UpdatedAt           string          `json:"updated_at"`
@@ -62,28 +62,28 @@ type RequestHeader struct {
 	Value string `json:"value"`
 }
 
-type relationships struct {
+type Relationships struct {
 	Policy struct {
 		Data string `json:"data,omitempty"`
 	} `json:"policy,omitempty"`
 	OncallUsers struct {
-		Data []user `json:"data,omitempty"`
+		Data []User `json:"data,omitempty"`
 	} `json:"on_call_users,omitempty"`
 	Monitor struct {
-		Data data `json:"data"`
+		Data Data `json:"data"`
 	} `json:"monitor,omitempty"`
 	Owner struct {
-		Data data `json:"data,omitempty"`
+		Data Data `json:"data,omitempty"`
 	} `json:"owner"`
 	WebhookIntegration struct {
-		Data data `json:"data,omitempty"`
+		Data Data `json:"data,omitempty"`
 	} `json:"webhook_integration,omitempty"`
 	StatusUpdates struct {
-		Data []data
+		Data []Data
 	}
 }
 
-type data struct {
+type Data struct {
 	ID   string `json:"id,omitempty"`
 	Type string `json:"type,omitempty"`
 }
@@ -93,19 +93,19 @@ type data struct {
 type MonitorResponseTime struct {
 	ID         string                 `json:"id"`
 	Type       string                 `json:"type"`
-	Attributes responseTimeAttributes `json:"attributes"`
+	Attributes ResponseTimeAttributes `json:"attributes"`
 }
 
-type responseTimeAttributes struct {
-	Regions []region `json:"regions"`
+type ResponseTimeAttributes struct {
+	Regions []Region `json:"regions"`
 }
 
-type region struct {
+type Region struct {
 	Region        string         `json:"region"`
-	ResponseTimes []responseTime `json:"response_times"`
+	ResponseTimes []ResponseTime `json:"response_times"`
 }
 
-type responseTime struct {
+type ResponseTime struct {
 	At           string  `json:"at"`
 	ResponseTime float64 `json:"response_time"`
 }
@@ -114,10 +114,10 @@ type responseTime struct {
 type MonitorAvailability struct {
 	ID         string                 `json:"id"`
 	Type       string                 `json:"type"`
-	Attributes availabilityAttributes `json:"attributes"`
+	Attributes AvailabilityAttributes `json:"attributes"`
 }
 
-type availabilityAttributes struct {
+type AvailabilityAttributes struct {
 	Availability      float64 `json:"availability,omitempty"`
 	TotalDownTime     int     `json:"total_down_time,omitempty"` // time in seconds
 	NumberOfIncidents int     `json:"number_of_incidents,omitempty"`

--- a/models/monitors_response.go
+++ b/models/monitors_response.go
@@ -33,7 +33,7 @@ type MonitorAttributes struct {
 	AuthPassword        string          `json:"auth_password"`
 	RequestTimeout      int             `json:"request_timeout"`
 	RecoveryPeriod      int             `json:"recovery_period"`
-	RequestHeaders      []requestHeader `json:"request_headers"`
+	RequestHeaders      []RequestHeader `json:"request_headers"`
 	RequestBody         string          `json:"request_body"`
 	FollowRedirects     bool            `json:"follow_redirects"`
 	RememberCookies     bool            `json:"remember_cookies"`
@@ -56,7 +56,7 @@ type MonitorAttributes struct {
 	ScenarioName        string          `json:"scenario_name"`
 }
 
-type requestHeader struct {
+type RequestHeader struct {
 	ID    string `json:"id,omitempty"`
 	Name  string `json:"name"`
 	Value string `json:"value"`

--- a/models/newrelic_response.go
+++ b/models/newrelic_response.go
@@ -3,16 +3,16 @@ package models
 // NewRelics is a list of NewRelic integrations
 type NewRelics struct {
 	Data       []NewRelic `json:"data"`
-	Pagination pagination `json:"pagination"`
+	Pagination Pagination `json:"pagination"`
 }
 
 // NewRelic is a NewRelic integration
 type NewRelic struct {
-	data
-	Attributes newRelicAttributes `json:"attributes"`
+	Data
+	Attributes NewRelicAttributes `json:"attributes"`
 }
 
-type newRelicAttributes struct {
+type NewRelicAttributes struct {
 	Call           bool   `json:"call"`
 	Sms            bool   `json:"sms"`
 	Email          bool   `json:"email"`

--- a/models/oncall_response.go
+++ b/models/oncall_response.go
@@ -3,31 +3,31 @@ package models
 // OncallCalendars represents the response structure for on-call calendars.
 type OncallCalendars struct {
 	Data       []OncallCalendar `json:"data,omitempty"`
-	Included   []user           `json:"included,omitempty"`
-	Pagination pagination       `json:"pagination,omitempty"`
+	Included   []User           `json:"included,omitempty"`
+	Pagination Pagination       `json:"pagination,omitempty"`
 }
 
 // OncallCalendar represents the on-call calendar information.
 type OncallCalendar struct {
 	ID            string           `json:"id,omitempty"`
 	Type          string           `json:"type,omitempty"`
-	Attributes    oncallAttributes `json:"attributes,omitempty"`
-	Relationships relationships    `json:"relationships,omitempty"`
+	Attributes    OncallAttributes `json:"attributes,omitempty"`
+	Relationships Relationships    `json:"relationships,omitempty"`
 }
 
-type oncallAttributes struct {
+type OncallAttributes struct {
 	Name            string `json:"name,omitempty"`
 	DefaultCalendar bool   `json:"default_calendar,omitempty"`
 }
 
-type user struct {
+type User struct {
 	ID         string         `json:"id"`
 	Type       string         `json:"type"`
 	Name       string         `json:"name,omitempty"`
-	Attributes userAttributes `json:"attributes,omitempty"`
+	Attributes UserAttributes `json:"attributes,omitempty"`
 }
 
-type userAttributes struct {
+type UserAttributes struct {
 	FirstName    string   `json:"first_name,omitempty"`
 	LastName     string   `json:"last_name,omitempty"`
 	Email        string   `json:"email,omitempty"`

--- a/models/policies_response.go
+++ b/models/policies_response.go
@@ -2,7 +2,7 @@ package models
 
 type EscalationPolicies struct {
 	Data       []EscalationPolicy `json:"data"`
-	Pagination pagination         `json:"pagination"`
+	Pagination Pagination         `json:"pagination"`
 }
 
 type EscalationPolicy struct {

--- a/models/query_response.go
+++ b/models/query_response.go
@@ -3,7 +3,7 @@ package models
 // Logs represents a response containing a list of logs
 type Logs struct {
 	Data       []log      `json:"data"`
-	Pagination pagination `json:"pagination"`
+	Pagination Pagination `json:"pagination"`
 }
 
 type log struct {

--- a/models/response.go
+++ b/models/response.go
@@ -1,6 +1,6 @@
 package models
 
-type pagination struct {
+type Pagination struct {
 	First string `json:"first"`
 	Last  string `json:"last"`
 	Prev  string `json:"prev"`

--- a/models/source_request.go
+++ b/models/source_request.go
@@ -12,7 +12,7 @@ type UpdateSourceBodyParams struct {
 	IngestingPaused bool   `json:"ingesting_paused"` // Enable or disable ingesting for this source
 }
 
-type platform struct {
+type Platform struct {
 	Apache2           string
 	AwsCloudwatch     string
 	AwsEcs            string
@@ -56,7 +56,7 @@ type platform struct {
 }
 
 // PlatformList is the list of supported platforms
-var PlatformList = platform{
+var PlatformList = Platform{
 	Apache2:           "apache2",
 	AwsCloudwatch:     "aws_cloudwatch",
 	AwsEcs:            "aws_ecs",

--- a/models/sources_response.go
+++ b/models/sources_response.go
@@ -9,10 +9,10 @@ type Sources struct {
 // Source represents a log source.
 type Source struct {
 	Data
-	Attributes sourcesAttributes `json:"attributes"`
+	Attributes SourcesAttributes `json:"attributes"`
 }
 
-type sourcesAttributes struct {
+type SourcesAttributes struct {
 	TeamID                int      `json:"team_id"`
 	Name                  string   `json:"name"`
 	TableName             string   `json:"table_name"`

--- a/models/sources_response.go
+++ b/models/sources_response.go
@@ -3,12 +3,12 @@ package models
 // Sources represents a response containing a list of log sources.
 type Sources struct {
 	Data       []Source   `json:"data"`
-	Pagination pagination `json:"pagination,omitempty"`
+	Pagination Pagination `json:"pagination,omitempty"`
 }
 
 // Source represents a log source.
 type Source struct {
-	data
+	Data
 	Attributes sourcesAttributes `json:"attributes"`
 }
 

--- a/models/status_reports_response.go
+++ b/models/status_reports_response.go
@@ -3,19 +3,19 @@ package models
 // StatusPageReports represents a response body for a list of status page reports
 type StatusPageReports struct {
 	Data       []StatusPageReport `json:"data,omitempty"`
-	Pagination pagination         `json:"pagination,omitempty"`
+	Pagination Pagination         `json:"pagination,omitempty"`
 }
 
 type statusPageReportData struct {
-	data
+	Data
 	Attributes    reportAttributes `json:"attributes,omitempty"`
-	Relationships relationships    `json:"relationships,omitempty"`
+	Relationships Relationships    `json:"relationships,omitempty"`
 }
 
 // StatusPageReport represents a status report for a status page.
 type StatusPageReport struct {
 	Data     statusPageReportData
-	Included []included `json:"included,omitempty"`
+	Included []Included `json:"included,omitempty"`
 }
 
 type reportAttributes struct {
@@ -28,12 +28,12 @@ type reportAttributes struct {
 	AggregateState    string             `json:"aggregate_state,omitempty"`
 }
 
-type included struct {
-	data
-	Attributes includedAttributes `json:"attributes"`
+type Included struct {
+	Data
+	Attributes IncludedAttributes `json:"attributes"`
 }
 
-type includedAttributes struct {
+type IncludedAttributes struct {
 	Message           string             `json:"message"`
 	PublishedAt       string             `json:"published_at"`
 	StatusReportID    int                `json:"status_report_id"`

--- a/models/status_reports_response.go
+++ b/models/status_reports_response.go
@@ -6,7 +6,7 @@ type StatusPageReports struct {
 	Pagination Pagination         `json:"pagination,omitempty"`
 }
 
-type statusPageReportData struct {
+type StatusPageReportData struct {
 	Data
 	Attributes    reportAttributes `json:"attributes,omitempty"`
 	Relationships Relationships    `json:"relationships,omitempty"`
@@ -14,7 +14,7 @@ type statusPageReportData struct {
 
 // StatusPageReport represents a status report for a status page.
 type StatusPageReport struct {
-	Data     statusPageReportData
+	Data     StatusPageReportData
 	Included []Included `json:"included,omitempty"`
 }
 

--- a/models/status_resources_response.go
+++ b/models/status_resources_response.go
@@ -3,16 +3,16 @@ package models
 // StatusPageResources represents the response containing status page resources
 type StatusPageResources struct {
 	Data       []StatusPageResource
-	Pagination pagination
+	Pagination Pagination
 }
 
 // StatusPageResource represents a status page resource.
 type StatusPageResource struct {
-	data
-	Attributes resourceAttributes `json:"attributes,omitempty"`
+	Data
+	Attributes ResourceAttributes `json:"attributes,omitempty"`
 }
 
-type resourceAttributes struct {
+type ResourceAttributes struct {
 	StatusPageSectionID int             `json:"status_page_section_id"`
 	ResourceID          int             `json:"resource_id"`
 	ResourceType        string          `json:"resource_type"`
@@ -22,10 +22,10 @@ type resourceAttributes struct {
 	Explanation         string          `json:"explanation"`
 	Position            int             `json:"position"`
 	Availability        float64         `json:"availability"`
-	StatusHistory       []statusHistory `json:"status_history"`
+	StatusHistory       []StatusHistory `json:"status_history"`
 }
 
-type statusHistory struct {
+type StatusHistory struct {
 	Day                 string `json:"day,omitempty"`
 	Status              string `json:"status,omitempty"`
 	DowntimeDuration    int    `json:"downtime_duration,omitempty"`

--- a/models/status_response.go
+++ b/models/status_response.go
@@ -3,17 +3,17 @@ package models
 // StatusPages represents a collection of status pages.
 type StatusPages struct {
 	Data       []StatusPage `json:"data,omitempty"`       // Data contains the list of status pages.
-	Pagination pagination   `json:"pagination,omitempty"` // Pagination contains the pagination information.
+	Pagination Pagination   `json:"pagination,omitempty"` // Pagination contains the pagination information.
 }
 
 // StatusPage represents a status page object.
 type StatusPage struct {
 	ID         string               `json:"id,omitempty"`
 	Type       string               `json:"type,omitempty"`
-	Attributes statusPageAttributes `json:"attributes,omitempty"`
+	Attributes StatusPageAttributes `json:"attributes,omitempty"`
 }
 
-type statusPageAttributes struct {
+type StatusPageAttributes struct {
 	CompanyName              string `json:"company_name,omitempty"`
 	CompanyURL               string `json:"company_url,omitempty"`
 	ContactURL               string `json:"contact_url,omitempty"`

--- a/models/status_sections_response.go
+++ b/models/status_sections_response.go
@@ -3,17 +3,17 @@ package models
 // StatusPageSections represents a collection of status pages.
 type StatusPageSections struct {
 	Data       []StatusPageSection `json:"data,omitempty"`       // Data contains the list of status pages.
-	Pagination pagination          `json:"pagination,omitempty"` // Pagination contains the pagination information.
+	Pagination Pagination          `json:"pagination,omitempty"` // Pagination contains the pagination information.
 }
 
 // StatusPageSection represents a status page object.
 type StatusPageSection struct {
 	ID         string                      `json:"id,omitempty"`
 	Type       string                      `json:"type,omitempty"`
-	Attributes statusPageSectionAttributes `json:"attributes,omitempty"`
+	Attributes StatusPageSectionAttributes `json:"attributes,omitempty"`
 }
 
-type statusPageSectionAttributes struct {
+type StatusPageSectionAttributes struct {
 	StatusPageID int    `json:"status_page_id,omitempty"`
 	Name         string `json:"name,omitempty"`
 	Position     int    `json:"position,omitempty"`

--- a/models/status_updates_response.go
+++ b/models/status_updates_response.go
@@ -2,12 +2,12 @@ package models
 
 // StatusUpdates represents a collection of status updates with pagination information.
 type StatusUpdates struct {
-	Data       []StatusUpdate
-	Pagination Pagination
+	Data       []StatusUpdate `json:"data"`
+	Pagination Pagination     `json:"pagination"`
 }
 
 // StatusUpdate represents an individual status update with its attributes.
 type StatusUpdate struct {
 	Data
-	Attributes IncludedAttributes
+	Attributes IncludedAttributes `json:"attributes"`
 }

--- a/models/status_updates_response.go
+++ b/models/status_updates_response.go
@@ -3,11 +3,11 @@ package models
 // StatusUpdates represents a collection of status updates with pagination information.
 type StatusUpdates struct {
 	Data       []StatusUpdate
-	Pagination pagination
+	Pagination Pagination
 }
 
 // StatusUpdate represents an individual status update with its attributes.
 type StatusUpdate struct {
-	data
-	Attributes includedAttributes
+	Data
+	Attributes IncludedAttributes
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
	- Updated naming conventions across multiple model response files
	- Capitalized struct and field names to follow Go export conventions
	- Improved type visibility for better package accessibility

- **Refactor**
	- Renamed unexported types to exported types (e.g., `pagination` → `Pagination`)
	- Standardized capitalization of struct and field names
	- Enhanced type naming consistency across model response files
<!-- end of auto-generated comment: release notes by coderabbit.ai -->